### PR TITLE
Fixing gallery type and optimization

### DIFF
--- a/actions.php
+++ b/actions.php
@@ -19,13 +19,9 @@ $app->on('collections.find.after', function ($name, &$data) use ($app) {
     foreach ($entry as $fieldName => $values) {    
       
       // Check if current field in entry is defined by user, we don't want '_id' etc. to proceed.
-      if(!array_key_exists($fieldName, $fields)) {
+      if (!isset($fields[$fieldName])) {
         continue;
       }
-
-      // Optionally check if current field is one of four special types
-      // Without this, types like Date might end in switch default (although conditionals will stop them, because nobody will put "styles" there)
-      //if(!in_array($fields[$fieldName]['type'], ['repeater', 'set', 'gallery', 'image'])) { continue; }
 
       switch ($fields[$fieldName]['type']) {
         case 'repeater':


### PR DESCRIPTION
While testing the script locally and after setting proper field definitions, I found out that only Image type was processed properly, not the Gallery type (Set and Repeater was not checked).

Unless it is a specific problem which occurs only in my environment, I believe there might be a bug in the master script.

PROBLEM
The original switch statement tests $field['type']. As far as I understand the `$field` variable is set inside 'Image case' and its purpose is to be an alias for `$fields[$fieldName]` only for this particular iteration. But the variable is never purified, so it influence not only next iterations, but also the switch statement itself.

ACTIONS
1. I changed switch variable to `$fields[$fieldName]['type']` so it could always check proper type from the source.
2. I changed `default` to `case 'image'` so we could always be sure that current type is one of four special types (earlier a Date type would pass to the default and then the conditionals were responsible for breaking the iteration.)
3. I optimized the IF statements in gallery and image cases (I left the necessary minimum in my opinion but still testing if i am not wrong..)
4. I put `(array)` before style definition to be sure that even if the user uses string instead of array, it will not break the proper iteration.